### PR TITLE
Add support for Geometric Algorithms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ RUN apt-get update && \
     unixodbc-dev \
     r-cran-rodbc \
     gfortran \
-    gcc && \
+    gcc \
+    ffmpeg \
+    dvipng \
+    cm-super \ 
+    && \
     rm -rf /var/lib/apt/lists/*
 
 # Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
@@ -44,9 +48,65 @@ RUN conda install --quiet --yes \
     'r-tidyverse=1.3*' \
     'unixodbc=2.3.*' \
     'r-tidymodels=0.1*' \
+    'beautifulsoup4=4.9.*' \
+    'conda-forge::blas=*=openblas' \
+    'bokeh=2.2.*' \
+    'bottleneck=1.3.*' \
+    'cloudpickle=1.6.*' \
+    'cython=0.29.*' \
+    'dask=2.25.*' \
+    'dill=0.3.*' \
+    'h5py=2.10.*' \
+    'ipywidgets=7.5.*' \
+    'ipympl=0.5.*'\
+    'matplotlib-base=3.3.*' \
+    'numba=0.51.*' \
+    'numexpr=2.7.*' \
+    'pandas=1.1.*' \
+    'patsy=0.5.*' \
+    'protobuf=3.12.*' \
+    'pytables=3.6.*' \
+    'scikit-image=0.17.*' \
+    'scikit-learn=0.23.*' \
+    'scipy=1.5.*' \
+    'seaborn=0.11.*' \
+    'sqlalchemy=1.3.*' \
+    'statsmodels=0.12.*' \
+    'sympy=1.6.*' \
+    'vincent=0.4.*' \
+    'widgetsnbextension=3.5.*'\
+    'xlrd=1.2.*' \
     && \
     conda clean --all -f -y && \
-    fix-permissions "${CONDA_DIR}"
+    jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^2.0.0 --no-build && \
+    jupyter labextension install @bokeh/jupyter_bokeh@^2.0.0 --no-build && \
+    jupyter labextension install jupyter-matplotlib@^0.7.2 --no-build && \
+    jupyter lab build -y && \
+    jupyter lab clean -y && \
+    npm cache clean --force && \
+    rm -rf "/home/${NB_USER}/.cache/yarn" && \
+    rm -rf "/home/${NB_USER}/.node-gyp" && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
 # Install e1071 R package (dependency of the caret R package)
 RUN conda install --quiet --yes r-e1071
+
+# Install facets which does not have a pip or conda package at the moment
+WORKDIR /tmp
+RUN git clone https://github.com/PAIR-code/facets.git && \
+    jupyter nbextension install facets/facets-dist/ --sys-prefix && \
+    rm -rf /tmp/facets && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# Import matplotlib the first time to build the font cache.
+ENV XDG_CACHE_HOME="/home/${NB_USER}/.cache/"
+
+RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot" && \
+    fix-permissions "/home/${NB_USER}"
+
+USER $NB_UID
+
+WORKDIR $HOME

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sem3-notebook
-One image to rule them all (RPiS and PF). 😎
+One image to rule them all (RPiS, PF and AG). 😎
 
-This image is a combined R + Haskell Jupyter Notebook. It uses `crosscompass/ihaskell-notebook` as its base and adds R to it using exact recipe as `jupyter/r-notebook`.
+This image is a combined R + Haskell + SciPy Jupyter Notebook. It uses `crosscompass/ihaskell-notebook` as its base, adds R to it using exact recipe as `jupyter/r-notebook` and python libraries from `jupyter/scipy-notebook`.
 
 🙏 God bless the people behind Jupyter Docker Stacks. 🙏
 


### PR DESCRIPTION
Adds libraries and dependencies to support Geometric Algorithms, mainly `numpy`, `matplotlib`, `pandas`, `seaborn`, 'scipy' etc.
Recipes are plain copy-paste from [`jupyter/scipy-notebook`](https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile).